### PR TITLE
moved readme to main page and added linkbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ If your support question or issue is related to a non-modified sample (or test) 
 The PI Vision Extensibility Samples in this repository are licensed under the [Apache 2 license](https://github.com/osisoft/OSI-Samples/blob/master/LICENSE).
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/PI%20Vision/extensibility-sample.unit-tests?branchName=47718_ExtensibilitySample)](https://dev.azure.com/osieng/engineering/_build?definitionId=1311&branchName=47718_ExtensibilitySample)
+
+---
+
+For the main PI Vision Extensibility landing page on master [ReadMe](https://github.com/osisoft/OSI-Samples-PI-System/tree/master/docs/PI-Vision-Extensibility-Docs)
+
+For the main PI System Samples landing page on master [ReadMe](https://github.com/osisoft/OSI-Samples-PI-System)
+
+For the main OSIsoft Samples landing page on master [ReadMe](https://github.com/osisoft/OSI-Samples)


### PR DESCRIPTION
- moved the readme to the root level
- added link backs to the vision extensibility page, pi system samples, and osisoft samples